### PR TITLE
Add additional user and moderation commands

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
+from datetime import datetime
 
 import discord
 from discord.ext import commands
@@ -24,7 +25,9 @@ class CappuccinoBot(commands.Bot):
     def __init__(self, prefix: str) -> None:
         intents = discord.Intents.default()
         intents.message_content = True
+        intents.members = True
         super().__init__(command_prefix=prefix, intents=intents)
+        self.launch_time = datetime.utcnow()
 
     async def setup_hook(self) -> None:  # type: ignore[override]
         successes, failures = await self.load_all_extensions()

--- a/commands/avatar.py
+++ b/commands/avatar.py
@@ -1,0 +1,49 @@
+import logging
+from datetime import datetime
+
+import discord
+from discord.ext import commands
+
+from utils import error_embed
+
+log = logging.getLogger(__name__)
+
+
+class Avatar(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def _reply(self, ctx: commands.Context, **kwargs) -> None:
+        if ctx.interaction:
+            if ctx.interaction.response.is_done():
+                await ctx.interaction.followup.send(**kwargs)
+            else:
+                await ctx.interaction.response.send_message(**kwargs)
+        else:
+            await ctx.send(**kwargs)
+
+    @commands.hybrid_command(name="avatar", description="Show a user's avatar")
+    @commands.cooldown(1, 5, commands.BucketType.user)
+    async def avatar(self, ctx: commands.Context, user: discord.User | None = None) -> None:
+        target = user or ctx.author
+        try:
+            asset = target.display_avatar.replace(size=1024)
+            formats = [f"[{fmt}]({asset.replace(format=fmt)})" for fmt in ("png", "webp", "jpg")]
+            if asset.is_animated():
+                formats.append(f"[gif]({asset.replace(format='gif')})")
+            embed = discord.Embed(
+                title=f"\U0001F4F7 Avatar – {target}",
+                description=" | ".join(formats),
+                color=0x42A5F5,
+                timestamp=datetime.utcnow(),
+            )
+            embed.set_image(url=asset)
+            embed.set_footer(text="Brewed with love \u2615\ufe0f\u2728")
+            await self._reply(ctx, embed=embed)
+        except Exception:
+            log.exception("avatar failed")
+            await self._reply(ctx, embed=error_embed(desc="Failed to fetch avatar"))
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Avatar(bot))

--- a/commands/banner.py
+++ b/commands/banner.py
@@ -1,0 +1,53 @@
+import logging
+from datetime import datetime
+
+import discord
+from discord.ext import commands
+
+from utils import error_embed
+
+log = logging.getLogger(__name__)
+
+
+class Banner(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def _reply(self, ctx: commands.Context, **kwargs) -> None:
+        if ctx.interaction:
+            if ctx.interaction.response.is_done():
+                await ctx.interaction.followup.send(**kwargs)
+            else:
+                await ctx.interaction.response.send_message(**kwargs)
+        else:
+            await ctx.send(**kwargs)
+
+    @commands.hybrid_command(name="banner", description="Show a user's banner")
+    @commands.cooldown(1, 5, commands.BucketType.user)
+    async def banner(self, ctx: commands.Context, user: discord.User | None = None) -> None:
+        target = user or ctx.author
+        try:
+            fetched = await self.bot.fetch_user(target.id)
+            if not fetched.banner:
+                await self._reply(ctx, embed=error_embed(desc="This user has no banner."))
+                return
+            asset = fetched.banner.replace(size=1024)
+            formats = [f"[{fmt}]({asset.replace(format=fmt)})" for fmt in ("png", "webp", "jpg")]
+            if asset.is_animated():
+                formats.append(f"[gif]({asset.replace(format='gif')})")
+            embed = discord.Embed(
+                title=f"\U0001F3A8 Banner – {fetched}",
+                description=" | ".join(formats),
+                color=0x42A5F5,
+                timestamp=datetime.utcnow(),
+            )
+            embed.set_image(url=asset)
+            embed.set_footer(text="Brewed with love \u2615\ufe0f\u2728")
+            await self._reply(ctx, embed=embed)
+        except Exception:
+            log.exception("banner failed")
+            await self._reply(ctx, embed=error_embed(desc="Failed to fetch banner"))
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Banner(bot))

--- a/commands/botinfo.py
+++ b/commands/botinfo.py
@@ -1,0 +1,52 @@
+import logging
+import platform
+from datetime import datetime
+
+import discord
+from discord.ext import commands
+
+from utils import error_embed, humanize_delta
+
+log = logging.getLogger(__name__)
+
+
+class BotInfo(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def _reply(self, ctx: commands.Context, **kwargs) -> None:
+        if ctx.interaction:
+            if ctx.interaction.response.is_done():
+                await ctx.interaction.followup.send(**kwargs)
+            else:
+                await ctx.interaction.response.send_message(**kwargs)
+        else:
+            await ctx.send(**kwargs)
+
+    @commands.hybrid_command(name="botinfo", description="Information about Cappuccino bot")
+    async def botinfo(self, ctx: commands.Context) -> None:
+        try:
+            uptime = datetime.utcnow() - getattr(self.bot, "launch_time", datetime.utcnow())
+            user_count = sum(g.member_count or 0 for g in self.bot.guilds)
+            embed = discord.Embed(
+                title="\U0001F916 Cappuccino Info",
+                color=0x42A5F5,
+                timestamp=datetime.utcnow(),
+            )
+            embed.set_thumbnail(url=self.bot.user.display_avatar.url)
+            embed.add_field(name="ID", value=str(self.bot.user.id), inline=True)
+            embed.add_field(name="Guilds", value=str(len(self.bot.guilds)), inline=True)
+            embed.add_field(name="Users", value=str(user_count), inline=True)
+            embed.add_field(name="Uptime", value=humanize_delta(uptime.total_seconds()), inline=True)
+            embed.add_field(name="Python", value=platform.python_version(), inline=True)
+            embed.add_field(name="discord.py", value=discord.__version__, inline=True)
+            embed.add_field(name="Latency", value=f"{self.bot.latency*1000:.0f} ms", inline=True)
+            embed.set_footer(text="Brewed with love \u2615\ufe0f\u2728")
+            await self._reply(ctx, embed=embed)
+        except Exception:
+            log.exception("botinfo failed")
+            await self._reply(ctx, embed=error_embed(desc="Failed to gather info"))
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(BotInfo(bot))

--- a/commands/firstmessage.py
+++ b/commands/firstmessage.py
@@ -1,0 +1,55 @@
+import logging
+from datetime import datetime
+
+import discord
+from discord.ext import commands
+
+from utils import error_embed
+
+log = logging.getLogger(__name__)
+
+
+class FirstMessage(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def _reply(self, ctx: commands.Context, **kwargs) -> None:
+        if ctx.interaction:
+            if ctx.interaction.response.is_done():
+                await ctx.interaction.followup.send(**kwargs)
+            else:
+                await ctx.interaction.response.send_message(**kwargs)
+        else:
+            await ctx.send(**kwargs)
+
+    @commands.hybrid_command(name="firstmessage", description="Show the first message in a channel")
+    async def firstmessage(self, ctx: commands.Context, channel: discord.TextChannel | None = None) -> None:
+        target = channel or ctx.channel
+        if not isinstance(target, discord.TextChannel):
+            await self._reply(ctx, embed=error_embed(desc="Channel type not supported."))
+            return
+        try:
+            msg = None
+            async for m in target.history(limit=1, oldest_first=True):
+                msg = m
+            if msg is None:
+                await self._reply(ctx, embed=error_embed(desc="Channel has no messages."))
+                return
+            content = (msg.content[:180] + "...") if len(msg.content) > 180 else msg.content
+            embed = discord.Embed(
+                title=f"\U0001F4AC First Message – #{target.name}",
+                description=content or "(embed/attachment)",
+                color=0x42A5F5,
+                timestamp=datetime.utcnow(),
+            )
+            embed.add_field(name="Author", value=msg.author.mention, inline=True)
+            embed.add_field(name="Jump", value=f"[Link]({msg.jump_url})", inline=True)
+            embed.set_footer(text="Brewed with love \u2615\ufe0f\u2728")
+            await self._reply(ctx, embed=embed)
+        except Exception:
+            log.exception("firstmessage failed")
+            await self._reply(ctx, embed=error_embed(desc="Failed to fetch first message"))
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(FirstMessage(bot))

--- a/commands/invite.py
+++ b/commands/invite.py
@@ -1,0 +1,46 @@
+import logging
+from datetime import datetime
+
+import discord
+from discord.ext import commands
+
+from utils import error_embed
+
+INVITE_URL = "https://example.com/invite"
+SUPPORT_URL = "https://example.com/support"
+
+log = logging.getLogger(__name__)
+
+
+class Invite(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def _reply(self, ctx: commands.Context, **kwargs) -> None:
+        if ctx.interaction:
+            if ctx.interaction.response.is_done():
+                await ctx.interaction.followup.send(**kwargs)
+            else:
+                await ctx.interaction.response.send_message(**kwargs)
+        else:
+            await ctx.send(**kwargs)
+
+    @commands.hybrid_command(name="invite", description="Show the bot's invite and support links")
+    async def invite(self, ctx: commands.Context) -> None:
+        try:
+            embed = discord.Embed(
+                title="\U0001F517 Invite Cappuccino",
+                color=0x42A5F5,
+                timestamp=datetime.utcnow(),
+            )
+            embed.add_field(name="Invite Link", value=f"[Click Here]({INVITE_URL})", inline=False)
+            embed.add_field(name="Support Server", value=f"[Join]({SUPPORT_URL})", inline=False)
+            embed.set_footer(text="Brewed with love \u2615\ufe0f\u2728")
+            await self._reply(ctx, embed=embed)
+        except Exception:
+            log.exception("invite command failed")
+            await self._reply(ctx, embed=error_embed(desc="Failed to create invite"))
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Invite(bot))

--- a/commands/lock.py
+++ b/commands/lock.py
@@ -1,0 +1,92 @@
+import logging
+from datetime import datetime
+
+import discord
+from discord.ext import commands
+
+from utils import error_embed
+
+log = logging.getLogger(__name__)
+
+
+def _send_perm_error(ctx: commands.Context, perm: str):
+    return error_embed(desc=f"You lack the required permission: {perm}")
+
+
+class ChannelLock(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def _reply(self, ctx: commands.Context, **kwargs) -> None:
+        if ctx.interaction:
+            if ctx.interaction.response.is_done():
+                await ctx.interaction.followup.send(**kwargs)
+            else:
+                await ctx.interaction.response.send_message(**kwargs)
+        else:
+            await ctx.send(**kwargs)
+
+    @commands.hybrid_command(name="lock", description="Lock a channel for @everyone")
+    @commands.has_permissions(manage_channels=True)
+    async def lock(self, ctx: commands.Context, channel: discord.TextChannel | None = None, *, reason: str | None = None) -> None:
+        target = channel or ctx.channel
+        if not isinstance(target, discord.TextChannel):
+            await self._reply(ctx, embed=error_embed(desc="Channel type not supported."))
+            return
+        if not ctx.channel.permissions_for(ctx.author).manage_channels:
+            await self._reply(ctx, embed=_send_perm_error(ctx, "Manage Channels"))
+            return
+        try:
+            overwrite = target.overwrites_for(ctx.guild.default_role)
+            if overwrite.send_messages is False:
+                await self._reply(ctx, embed=error_embed(desc="Channel is already locked."))
+                return
+            overwrite.send_messages = False
+            await target.set_permissions(ctx.guild.default_role, overwrite=overwrite, reason=reason)
+            embed = discord.Embed(
+                title="\U0001F512 Channel Locked",
+                color=0xFFAA33,
+                timestamp=datetime.utcnow(),
+            )
+            embed.add_field(name="Channel", value=target.mention, inline=True)
+            embed.add_field(name="Reason", value=reason or "None", inline=True)
+            embed.add_field(name="Actor", value=ctx.author.mention, inline=True)
+            embed.set_footer(text="Brewed with love \u2615\ufe0f\u2728")
+            await self._reply(ctx, embed=embed)
+        except Exception:
+            log.exception("lock failed")
+            await self._reply(ctx, embed=error_embed(desc="Failed to lock channel"))
+
+    @commands.hybrid_command(name="unlock", description="Unlock a channel for @everyone")
+    @commands.has_permissions(manage_channels=True)
+    async def unlock(self, ctx: commands.Context, channel: discord.TextChannel | None = None) -> None:
+        target = channel or ctx.channel
+        if not isinstance(target, discord.TextChannel):
+            await self._reply(ctx, embed=error_embed(desc="Channel type not supported."))
+            return
+        if not ctx.channel.permissions_for(ctx.author).manage_channels:
+            await self._reply(ctx, embed=_send_perm_error(ctx, "Manage Channels"))
+            return
+        try:
+            overwrite = target.overwrites_for(ctx.guild.default_role)
+            if overwrite.send_messages is None or overwrite.send_messages is True:
+                await self._reply(ctx, embed=error_embed(desc="Channel is not locked."))
+                return
+            overwrite.send_messages = None
+            await target.set_permissions(ctx.guild.default_role, overwrite=overwrite)
+            embed = discord.Embed(
+                title="\U0001F513 Channel Unlocked",
+                color=0xFFAA33,
+                timestamp=datetime.utcnow(),
+            )
+            embed.add_field(name="Channel", value=target.mention, inline=True)
+            embed.add_field(name="Actor", value=ctx.author.mention, inline=True)
+            embed.set_footer(text="Brewed with love \u2615\ufe0f\u2728")
+            await self._reply(ctx, embed=embed)
+        except Exception:
+            log.exception("unlock failed")
+            await self._reply(ctx, embed=error_embed(desc="Failed to unlock channel"))
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(ChannelLock(bot))

--- a/commands/nickname.py
+++ b/commands/nickname.py
@@ -1,0 +1,56 @@
+import logging
+from datetime import datetime
+
+import discord
+from discord.ext import commands
+
+from utils import error_embed
+
+log = logging.getLogger(__name__)
+
+
+class Nickname(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def _reply(self, ctx: commands.Context, **kwargs) -> None:
+        if ctx.interaction:
+            if ctx.interaction.response.is_done():
+                await ctx.interaction.followup.send(**kwargs)
+            else:
+                await ctx.interaction.response.send_message(**kwargs)
+        else:
+            await ctx.send(**kwargs)
+
+    @commands.hybrid_command(name="nickname", description="Change a member's nickname")
+    @commands.has_permissions(manage_nicknames=True)
+    async def nickname(self, ctx: commands.Context, member: discord.Member, *, new_nick: str) -> None:
+        if not ctx.guild:
+            await self._reply(ctx, embed=error_embed(desc="Run this in a server."))
+            return
+        if not ctx.author.guild_permissions.manage_nicknames:
+            await self._reply(ctx, embed=error_embed(desc="You lack the required permission: Manage Nicknames"))
+            return
+        if member.top_role >= ctx.author.top_role and ctx.author != ctx.guild.owner:
+            await self._reply(ctx, embed=error_embed(desc="You cannot modify this member."))
+            return
+        try:
+            if new_nick in {"-", "reset"}:
+                new_nick = None
+            await member.edit(nick=new_nick, reason=f"By {ctx.author}")
+            embed = discord.Embed(
+                title="\u270F\ufe0f Nickname Updated",
+                color=0xFFAA33,
+                timestamp=datetime.utcnow(),
+            )
+            embed.add_field(name="Member", value=member.mention, inline=True)
+            embed.add_field(name="New Nick", value=new_nick or "None", inline=True)
+            embed.set_footer(text="Brewed with love \u2615\ufe0f\u2728")
+            await self._reply(ctx, embed=embed)
+        except Exception:
+            log.exception("nickname failed")
+            await self._reply(ctx, embed=error_embed(desc="Failed to change nickname"))
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Nickname(bot))

--- a/commands/poll.py
+++ b/commands/poll.py
@@ -1,0 +1,67 @@
+import logging
+from datetime import datetime
+
+import discord
+from discord.ext import commands
+
+from utils import error_embed, sanitize
+
+log = logging.getLogger(__name__)
+
+
+class Poll(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def _reply(self, ctx: commands.Context, **kwargs):
+        if ctx.interaction:
+            if ctx.interaction.response.is_done():
+                return await ctx.interaction.followup.send(**kwargs)
+            else:
+                return await ctx.interaction.response.send_message(**kwargs)
+        else:
+            return await ctx.send(**kwargs)
+
+    @commands.hybrid_command(name="poll", description="Create a simple reaction poll")
+    @commands.cooldown(1, 15, commands.BucketType.user)
+    async def poll(self, ctx: commands.Context, question: str, option1: str, option2: str, option3: str | None = None, option4: str | None = None) -> None:
+        options = [option1, option2]
+        if option3:
+            options.append(option3)
+        if option4:
+            options.append(option4)
+        if len(options) < 2 or len(options) > 4:
+            await self._reply(ctx, embed=error_embed(desc="Provide between 2 and 4 options."))
+            return
+        for opt in options:
+            if len(opt) > 100:
+                await self._reply(ctx, embed=error_embed(desc="Options must be under 100 characters."))
+                return
+        try:
+            emojis = ["1️⃣", "2️⃣", "3️⃣", "4️⃣"]
+            embed = discord.Embed(
+                title="\U0001F4CA Poll",
+                description=sanitize(question),
+                color=0x42A5F5,
+                timestamp=datetime.utcnow(),
+            )
+            for idx, opt in enumerate(options, start=1):
+                embed.add_field(name=f"{emojis[idx-1]}", value=sanitize(opt), inline=False)
+            embed.set_footer(text="Brewed with love \u2615\ufe0f\u2728")
+            message = await self._reply(ctx, embed=embed)
+            if isinstance(message, (discord.Message, discord.InteractionMessage)):
+                target_message = message
+            else:
+                return
+            for idx in range(len(options)):
+                try:
+                    await target_message.add_reaction(emojis[idx])
+                except Exception:
+                    pass
+        except Exception:
+            log.exception("poll failed")
+            await self._reply(ctx, embed=error_embed(desc="Failed to create poll"))
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Poll(bot))

--- a/commands/purge.py
+++ b/commands/purge.py
@@ -1,0 +1,58 @@
+import logging
+from datetime import datetime
+
+import discord
+from discord.ext import commands
+
+from utils import error_embed
+
+log = logging.getLogger(__name__)
+
+
+class Purge(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def _reply(self, ctx: commands.Context, **kwargs) -> None:
+        if ctx.interaction:
+            if ctx.interaction.response.is_done():
+                await ctx.interaction.followup.send(**kwargs)
+            else:
+                await ctx.interaction.response.send_message(**kwargs)
+        else:
+            await ctx.send(**kwargs)
+
+    @commands.hybrid_command(name="purge", description="Bulk delete messages")
+    @commands.has_permissions(manage_messages=True)
+    async def purge(self, ctx: commands.Context, amount: int, user: discord.Member | None = None) -> None:
+        if ctx.guild is None or not isinstance(ctx.channel, discord.TextChannel):
+            await self._reply(ctx, embed=error_embed(desc="Run this in a text channel."))
+            return
+        if amount < 1 or amount > 200:
+            await self._reply(ctx, embed=error_embed(desc="Amount must be between 1 and 200"))
+            return
+        if not ctx.channel.permissions_for(ctx.author).manage_messages:
+            await self._reply(ctx, embed=error_embed(desc="You lack the required permission: Manage Messages"))
+            return
+        try:
+            def check(m: discord.Message) -> bool:
+                return user is None or m.author.id == user.id
+
+            deleted = await ctx.channel.purge(limit=amount, check=check, bulk=True)
+            embed = discord.Embed(
+                title="\U0001F5D1\ufe0f Purge Complete",
+                color=0xFFAA33,
+                timestamp=datetime.utcnow(),
+            )
+            embed.add_field(name="Requested", value=str(amount), inline=True)
+            embed.add_field(name="Deleted", value=str(len(deleted)), inline=True)
+            embed.add_field(name="Filter", value=user.mention if user else "None", inline=True)
+            embed.set_footer(text="Brewed with love \u2615\ufe0f\u2728")
+            await self._reply(ctx, embed=embed)
+        except Exception:
+            log.exception("purge failed")
+            await self._reply(ctx, embed=error_embed(desc="Failed to purge messages"))
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Purge(bot))

--- a/commands/react.py
+++ b/commands/react.py
@@ -1,0 +1,48 @@
+import logging
+from datetime import datetime
+
+import discord
+from discord.ext import commands
+
+from utils import error_embed
+
+log = logging.getLogger(__name__)
+
+
+class React(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def _reply(self, ctx: commands.Context, **kwargs) -> None:
+        if ctx.interaction:
+            if ctx.interaction.response.is_done():
+                await ctx.interaction.followup.send(**kwargs)
+            else:
+                await ctx.interaction.response.send_message(**kwargs)
+        else:
+            await ctx.send(**kwargs)
+
+    @commands.hybrid_command(name="react", description="Add a reaction to a message")
+    async def react(self, ctx: commands.Context, message_id: int, emoji: str) -> None:
+        if not isinstance(ctx.channel, discord.TextChannel):
+            await self._reply(ctx, embed=error_embed(desc="Run in a text channel."))
+            return
+        try:
+            msg = await ctx.channel.fetch_message(message_id)
+            await msg.add_reaction(emoji)
+            embed = discord.Embed(
+                title="\u2705 Reaction Added",
+                color=0xFFAA33,
+                timestamp=datetime.utcnow(),
+            )
+            embed.add_field(name="Message", value=f"[Jump]({msg.jump_url})", inline=False)
+            embed.add_field(name="Emoji", value=emoji, inline=True)
+            embed.set_footer(text="Brewed with love \u2615\ufe0f\u2728")
+            await self._reply(ctx, embed=embed)
+        except Exception:
+            log.exception("react failed")
+            await self._reply(ctx, embed=error_embed(desc="Failed to add reaction"))
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(React(bot))

--- a/commands/roleinfo.py
+++ b/commands/roleinfo.py
@@ -1,0 +1,61 @@
+import logging
+from datetime import datetime
+
+import discord
+from discord.ext import commands
+
+from utils import error_embed
+
+log = logging.getLogger(__name__)
+
+
+class RoleInfo(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def _reply(self, ctx: commands.Context, **kwargs) -> None:
+        if ctx.interaction:
+            if ctx.interaction.response.is_done():
+                await ctx.interaction.followup.send(**kwargs)
+            else:
+                await ctx.interaction.response.send_message(**kwargs)
+        else:
+            await ctx.send(**kwargs)
+
+    @commands.hybrid_command(name="roleinfo", description="Information about a role")
+    async def roleinfo(self, ctx: commands.Context, role: discord.Role) -> None:
+        try:
+            perms = []
+            notable = [
+                ("Administrator", role.permissions.administrator),
+                ("Manage Messages", role.permissions.manage_messages),
+                ("Manage Channels", role.permissions.manage_channels),
+                ("Ban Members", role.permissions.ban_members),
+                ("Kick Members", role.permissions.kick_members),
+            ]
+            for name, has in notable:
+                if has:
+                    perms.append(name)
+            embed = discord.Embed(
+                title=f"\U0001F396\ufe0f Role Info – {role.name}",
+                color=role.color if role.color.value else 0xFFC0CB,
+                timestamp=datetime.utcnow(),
+            )
+            embed.add_field(name="ID", value=str(role.id), inline=True)
+            embed.add_field(name="Created", value=discord.utils.format_dt(role.created_at, "R"), inline=True)
+            embed.add_field(name="Position", value=str(role.position), inline=True)
+            embed.add_field(name="Color", value=str(role.color), inline=True)
+            embed.add_field(name="Members", value=str(len(role.members)), inline=True)
+            embed.add_field(name="Mentionable", value=str(role.mentionable), inline=True)
+            embed.add_field(name="Hoisted", value=str(role.hoist), inline=True)
+            embed.add_field(name="Managed", value=str(role.managed), inline=True)
+            embed.add_field(name="Key Perms", value=", ".join(perms) or "None", inline=False)
+            embed.set_footer(text="Brewed with love \u2615\ufe0f\u2728")
+            await self._reply(ctx, embed=embed)
+        except Exception:
+            log.exception("roleinfo failed")
+            await self._reply(ctx, embed=error_embed(desc="Failed to fetch role info"))
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(RoleInfo(bot))

--- a/commands/say.py
+++ b/commands/say.py
@@ -1,0 +1,53 @@
+import logging
+from datetime import datetime
+
+import discord
+from discord.ext import commands
+
+from utils import error_embed, sanitize
+
+log = logging.getLogger(__name__)
+
+
+class Say(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def _reply(self, ctx: commands.Context, **kwargs) -> None:
+        if ctx.interaction:
+            if ctx.interaction.response.is_done():
+                await ctx.interaction.followup.send(**kwargs)
+            else:
+                await ctx.interaction.response.send_message(**kwargs)
+        else:
+            await ctx.send(**kwargs)
+
+    @commands.hybrid_command(name="say", description="Have the bot repeat your message")
+    @commands.cooldown(1, 5, commands.BucketType.user)
+    async def say(self, ctx: commands.Context, *, message: str, as_embed: bool = False) -> None:
+        text = sanitize(message)
+        try:
+            if as_embed:
+                if len(text) > 1800:
+                    await self._reply(ctx, embed=error_embed(desc="Message too long for embed."))
+                    return
+                embed = discord.Embed(
+                    title="\U0001F4AC Say",
+                    description=text,
+                    color=0x42A5F5,
+                    timestamp=datetime.utcnow(),
+                )
+                embed.set_footer(text="Brewed with love \u2615\ufe0f\u2728")
+                await self._reply(ctx, embed=embed)
+            else:
+                if len(text) > 2000:
+                    await self._reply(ctx, embed=error_embed(desc="Message too long."))
+                    return
+                await self._reply(ctx, content=text)
+        except Exception:
+            log.exception("say failed")
+            await self._reply(ctx, embed=error_embed(desc="Failed to send message"))
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Say(bot))

--- a/commands/servericon.py
+++ b/commands/servericon.py
@@ -1,0 +1,54 @@
+import logging
+from datetime import datetime
+
+import discord
+from discord.ext import commands
+
+from utils import error_embed
+
+log = logging.getLogger(__name__)
+
+
+class ServerIcon(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def _reply(self, ctx: commands.Context, **kwargs) -> None:
+        if ctx.interaction:
+            if ctx.interaction.response.is_done():
+                await ctx.interaction.followup.send(**kwargs)
+            else:
+                await ctx.interaction.response.send_message(**kwargs)
+        else:
+            await ctx.send(**kwargs)
+
+    @commands.hybrid_command(name="servericon", description="Show the server's icon")
+    async def servericon(self, ctx: commands.Context) -> None:
+        guild = ctx.guild
+        if guild is None:
+            await self._reply(ctx, embed=error_embed(desc="Run this in a server."))
+            return
+        if not guild.icon:
+            await self._reply(ctx, embed=error_embed(desc="This server has no icon."))
+            return
+        try:
+            asset = guild.icon.replace(size=1024)
+            formats = [f"[{fmt}]({asset.replace(format=fmt)})" for fmt in ("png", "webp", "jpg")]
+            if asset.is_animated():
+                formats.append(f"[gif]({asset.replace(format='gif')})")
+            embed = discord.Embed(
+                title=f"\U0001F5BC Server Icon – {guild.name}",
+                description=" | ".join(formats),
+                color=0x42A5F5,
+                timestamp=datetime.utcnow(),
+            )
+            embed.set_image(url=asset)
+            embed.set_footer(text="Brewed with love \u2615\ufe0f\u2728")
+            await self._reply(ctx, embed=embed)
+        except Exception:
+            log.exception("servericon failed")
+            await self._reply(ctx, embed=error_embed(desc="Failed to fetch icon"))
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(ServerIcon(bot))

--- a/commands/serverinfo.py
+++ b/commands/serverinfo.py
@@ -1,0 +1,136 @@
+import logging
+import time
+from datetime import datetime
+from typing import Optional
+
+import discord
+from discord.ext import commands
+
+import io
+
+from utils import error_embed, chunk_string
+
+log = logging.getLogger(__name__)
+
+
+class ServerInfo(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def _reply(self, ctx: commands.Context, **kwargs) -> None:
+        if ctx.interaction:
+            if ctx.interaction.response.is_done():
+                await ctx.interaction.followup.send(**kwargs)
+            else:
+                await ctx.interaction.response.send_message(**kwargs)
+        else:
+            await ctx.send(**kwargs)
+
+    @commands.hybrid_command(
+        name="serverinfo",
+        description="Display a detailed snapshot of this server.",
+    )
+    async def serverinfo(
+        self,
+        ctx: commands.Context,
+        show_counts: bool = True,
+        show_roles: bool = True,
+        collapse_roles: bool = False,
+        show_emojis: bool = True,
+        show_boosters: bool = True,
+    ) -> None:
+        guild = ctx.guild
+        if guild is None:
+            await self._reply(ctx, embed=error_embed(desc="Run this in a server."))
+            return
+        start = time.perf_counter()
+        if ctx.interaction:
+            await ctx.interaction.response.defer()
+        try:
+            humans = sum(1 for m in guild.members if not m.bot)
+            bots = guild.member_count - humans
+            online = sum(1 for m in guild.members if m.status != discord.Status.offline)
+            text_channels = len(guild.text_channels)
+            voice_channels = len(guild.voice_channels)
+            categories = len(guild.categories)
+            threads = sum(len(ch.threads) for ch in guild.text_channels)
+            emoji_total = len(guild.emojis)
+            animated = sum(1 for e in guild.emojis if e.animated)
+            static = emoji_total - animated
+            boosters: Optional[list[discord.Member]] = guild.premium_subscribers
+            ws_latency = self.bot.latency * 1000
+            embed = discord.Embed(
+                title=f"\U0001F310 Server Info – {guild.name}",
+                color=0xFFC0CB,
+                timestamp=datetime.utcnow(),
+            )
+            embed.set_footer(text="Brewed with love ☕️✨")
+            if guild.icon:
+                embed.set_thumbnail(url=guild.icon.url)
+            embed.add_field(name="ID", value=guild.id, inline=True)
+            embed.add_field(
+                name="Created",
+                value=f"{discord.utils.format_dt(guild.created_at, 'R')} ({guild.created_at:%Y-%m-%d})",
+                inline=True,
+            )
+            embed.add_field(name="Owner", value=guild.owner.mention if guild.owner else "Unknown", inline=True)
+            if show_counts:
+                embed.add_field(
+                    name="Members",
+                    value=f"Total: **{guild.member_count}**\nHumans: {humans} | Bots: {bots}\nOnline: {online}",
+                    inline=False,
+                )
+                embed.add_field(
+                    name="Channels",
+                    value=f"Text: {text_channels} | Voice: {voice_channels} | Cat: {categories} | Threads: {threads}",
+                    inline=False,
+                )
+                embed.add_field(
+                    name="Other",
+                    value=f"Boost Lvl: {guild.premium_tier}\nLatency: {ws_latency:.0f} ms",
+                    inline=False,
+                )
+            send_file = None
+            if show_roles:
+                roles_sorted = [r for r in sorted(guild.roles, key=lambda r: r.position, reverse=True) if r != guild.default_role]
+                if collapse_roles:
+                    display = ", ".join(r.mention for r in roles_sorted[:10])
+                    if len(roles_sorted) > 10:
+                        display += " ..."
+                    embed.add_field(name=f"Roles ({len(roles_sorted)})", value=display or "None", inline=False)
+                else:
+                    role_mentions = [r.mention for r in roles_sorted]
+                    chunks = chunk_string(role_mentions)
+                    if len(roles_sorted) > 200 or sum(len(c) for c in chunks) > 6000:
+                        content = "\n".join(f"{r.name} ({r.id})" for r in roles_sorted)
+                        send_file = discord.File(io.BytesIO(content.encode("utf-8")), filename="roles.txt")
+                        embed.add_field(name=f"Roles ({len(roles_sorted)})", value="All roles included in attached file.", inline=False)
+                    else:
+                        for idx, part in enumerate(chunks, start=1):
+                            title = f"Roles ({idx}/{len(chunks)})" if len(chunks) > 1 else f"Roles ({len(roles_sorted)})"
+                            embed.add_field(name=title, value=part, inline=False)
+            if show_emojis:
+                embed.add_field(
+                    name=f"Emojis ({emoji_total})",
+                    value=f"Static: {static} | Animated: {animated}" if emoji_total else "None",
+                    inline=False,
+                )
+            if show_boosters and boosters:
+                sample = boosters[:10]
+                booster_value = " ".join(m.mention for m in sample)
+                if len(boosters) > 10:
+                    booster_value += f" +{len(boosters) - 10} more"
+                embed.add_field(name=f"Boosters ({len(boosters)})", value=booster_value, inline=False)
+            api_latency = (time.perf_counter() - start) * 1000
+            embed.add_field(name="API", value=f"{api_latency:.0f} ms", inline=False)
+            if send_file:
+                await self._reply(ctx, embed=embed, file=send_file)
+            else:
+                await self._reply(ctx, embed=embed)
+        except Exception:
+            log.exception("serverinfo failed")
+            await self._reply(ctx, embed=error_embed(desc="Failed to build server info."))
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(ServerInfo(bot))

--- a/commands/uptime.py
+++ b/commands/uptime.py
@@ -1,0 +1,44 @@
+import logging
+from datetime import datetime
+
+import discord
+from discord.ext import commands
+
+from utils import error_embed, humanize_delta
+
+log = logging.getLogger(__name__)
+
+
+class Uptime(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def _reply(self, ctx: commands.Context, **kwargs) -> None:
+        if ctx.interaction:
+            if ctx.interaction.response.is_done():
+                await ctx.interaction.followup.send(**kwargs)
+            else:
+                await ctx.interaction.response.send_message(**kwargs)
+        else:
+            await ctx.send(**kwargs)
+
+    @commands.hybrid_command(name="uptime", description="Show how long the bot has been running")
+    async def uptime(self, ctx: commands.Context) -> None:
+        try:
+            delta = datetime.utcnow() - getattr(self.bot, "launch_time", datetime.utcnow())
+            human = humanize_delta(delta.total_seconds())
+            embed = discord.Embed(
+                title="\u23F0 Uptime",
+                description=human,
+                color=0x42A5F5,
+                timestamp=datetime.utcnow(),
+            )
+            embed.set_footer(text="Brewed with love \u2615\ufe0f\u2728")
+            await self._reply(ctx, embed=embed)
+        except Exception:
+            log.exception("uptime command failed")
+            await self._reply(ctx, embed=error_embed(desc="Failed to get uptime"))
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Uptime(bot))

--- a/commands/userinfo.py
+++ b/commands/userinfo.py
@@ -1,0 +1,63 @@
+import logging
+from datetime import datetime
+
+import discord
+from discord.ext import commands
+
+from utils import error_embed
+
+log = logging.getLogger(__name__)
+
+
+class UserInfo(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def _reply(self, ctx: commands.Context, **kwargs) -> None:
+        if ctx.interaction:
+            if ctx.interaction.response.is_done():
+                await ctx.interaction.followup.send(**kwargs)
+            else:
+                await ctx.interaction.response.send_message(**kwargs)
+        else:
+            await ctx.send(**kwargs)
+
+    @commands.hybrid_command(name="userinfo", description="Detailed profile of a user in this guild")
+    async def userinfo(self, ctx: commands.Context, member: discord.Member | None = None) -> None:
+        if ctx.guild is None:
+            await self._reply(ctx, embed=error_embed(desc="Run this in a server."))
+            return
+        target = member or ctx.author
+        try:
+            fetched = await self.bot.fetch_user(target.id)
+            banner = fetched.banner
+            embed = discord.Embed(
+                title=f"\U0001F464 User Info – {target.display_name}",
+                color=0x42A5F5,
+                timestamp=datetime.utcnow(),
+            )
+            embed.set_thumbnail(url=target.display_avatar.url)
+            if banner:
+                embed.set_image(url=banner.url)
+            created = discord.utils.format_dt(target.created_at, "R")
+            joined = discord.utils.format_dt(target.joined_at, "R") if target.joined_at else "N/A"
+            roles = [r.mention for r in sorted(target.roles, key=lambda r: r.position, reverse=True) if r != ctx.guild.default_role]
+            embed.add_field(name="ID", value=str(target.id), inline=True)
+            embed.add_field(name="Created", value=created, inline=True)
+            embed.add_field(name="Joined", value=joined, inline=True)
+            embed.add_field(name="Top Role", value=target.top_role.mention, inline=True)
+            embed.add_field(name="Roles", value=", ".join(roles) or "None", inline=False)
+            embed.add_field(name="Booster", value="Yes" if target.premium_since else "No", inline=True)
+            if target.timed_out_until:
+                timeout = discord.utils.format_dt(target.timed_out_until, "R")
+                embed.add_field(name="Timeout", value=timeout, inline=True)
+            embed.add_field(name="Bot", value="Yes" if target.bot else "No", inline=True)
+            embed.set_footer(text="Brewed with love \u2615\ufe0f\u2728")
+            await self._reply(ctx, embed=embed)
+        except Exception:
+            log.exception("userinfo failed")
+            await self._reply(ctx, embed=error_embed(desc="Failed to fetch user info"))
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(UserInfo(bot))

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,39 @@
+import discord
+
+
+def humanize_delta(seconds: float) -> str:
+    seconds = int(seconds)
+    units = [("d", 86400), ("h", 3600), ("m", 60), ("s", 1)]
+    parts = []
+    for suffix, size in units:
+        value, seconds = divmod(seconds, size)
+        if value:
+            parts.append(f"{value}{suffix}")
+    return " ".join(parts) if parts else "0s"
+
+
+def error_embed(title: str = "\u26A0\ufe0f Error", desc: str = "Something went wrong.") -> discord.Embed:
+    return discord.Embed(title=title, description=desc, color=0xFF0000)
+
+
+def sanitize(text: str) -> str:
+    return text.replace("@everyone", "@\u200beveryone").replace("@here", "@\u200bhere")
+
+
+def chunk_string(items, sep: str = ", ", max_len: int = 1000) -> list[str]:
+    """Split items into chunks not exceeding ``max_len`` characters."""
+    chunks: list[str] = []
+    buf = ""
+    for it in items:
+        token = str(it)
+        token_len = len(token) if not buf else len(sep) + len(token)
+        if not buf:
+            buf = token
+        elif len(buf) + token_len <= max_len:
+            buf += sep + token
+        else:
+            chunks.append(buf)
+            buf = token
+    if buf:
+        chunks.append(buf)
+    return chunks


### PR DESCRIPTION
## Summary
- extend utilities with `chunk_string`
- upgrade `serverinfo` roles listing with full display or file fallback
- implement avatar, banner, userinfo, roleinfo, botinfo
- add moderation and fun commands: purge, lock/unlock, nickname, say, poll, firstmessage, servericon, react

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687c9f0c9628832c8d7a44ee0c0b3069