### PR TITLE
Add support and invite URL placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 DISCORD_BOT_TOKEN=YOUR_TOKEN_HERE
 BOT_PREFIX=c!
+SUPPORT_SERVER_URL=https://example.com/support
+BOT_INVITE_URL=https://example.com/invite

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
 # Cappuccino
 指示されたことに従い、DiscordBOTを完成させてください。
 また、bot.py にすべてのコマンドを書くのではなく、commands ディレクトリに配置した各 Python ファイルで個別に管理してください。
-DiscordBOT のトークンは `.env.example` に `DISCORD_BOT_TOKEN` として記載し、実際の値は `.env` に保存してください。
+DiscordBOT のトークンは `.env.example` に `DISCORD_BOT_TOKEN` として記載し、実際の値は `.env` に保存してください。さらに、サポートサーバーの URL と BOT の招待 URL を `SUPPORT_SERVER_URL`、`BOT_INVITE_URL` として追加し、`.env` で適切な値に置き換えてください。

--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ DiscordCappuccino/
 ```
 DISCORD_BOT_TOKEN=YOUR_TOKEN_HERE
 BOT_PREFIX=c!
+SUPPORT_SERVER_URL=https://example.com/support
+BOT_INVITE_URL=https://example.com/invite
 ...追加予定
 ```
 
-`.env.example` を `.env` にコピーしてトークンなどを編集してください。
+`.env.example` を `.env` にコピーしてトークンや各種URLを編集してください。
 
 ## 起動手順
 


### PR DESCRIPTION
## Summary
- extend `.env.example` with placeholders for support server and invite URLs
- mention new environment variables in README
- update `AGENTS.md` guidance about these variables

## Testing
- `python -m py_compile bot.py utils.py commands/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687ca70dd1c0832ca93ef062606e18b8