### PR TITLE
Improve time formatting in ping and uptime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ DISCORD_BOT_TOKEN=YOUR_TOKEN_HERE
 BOT_PREFIX=c!
 SUPPORT_SERVER_URL=https://example.com/support
 BOT_INVITE_URL=https://example.com/invite
+TIMEZONE=UTC

--- a/README.md
+++ b/README.md
@@ -21,10 +21,14 @@ DISCORD_BOT_TOKEN=YOUR_TOKEN_HERE
 BOT_PREFIX=c!
 SUPPORT_SERVER_URL=https://example.com/support
 BOT_INVITE_URL=https://example.com/invite
+TIMEZONE=UTC
 ...追加予定
 ```
 
-`.env.example` を `.env` にコピーしてトークンや各種URLを編集してください。
+`TIMEZONE` は `uptime` コマンドなどで使用する基準となるタイムゾーンを指定します。
+起動後に `/setup` コマンドを使うことでボット実行中にタイムゾーンを変更できます。
+
+`.env.example` を `.env` にコピーしてトークンや各種 URL を編集してください。
 
 ## 起動手順
 

--- a/bot.py
+++ b/bot.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
 import discord
 from discord.ext import commands
@@ -27,7 +28,13 @@ class CappuccinoBot(commands.Bot):
         intents.message_content = True
         intents.members = True
         super().__init__(command_prefix=prefix, intents=intents)
-        self.launch_time = datetime.utcnow()
+        tz_name = os.getenv("TIMEZONE", "UTC")
+        try:
+            self.timezone = ZoneInfo(tz_name)
+        except Exception:
+            log.warning("Invalid TIMEZONE %s, falling back to UTC", tz_name)
+            self.timezone = ZoneInfo("UTC")
+        self.launch_time = datetime.now(timezone.utc)
 
     async def setup_hook(self) -> None:  # type: ignore[override]
         successes, failures = await self.load_all_extensions()

--- a/commands/ping.py
+++ b/commands/ping.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from datetime import datetime
 
 import discord
 from discord.ext import commands
@@ -39,7 +40,9 @@ class Ping(commands.Cog):
             embed.add_field(
                 name="\U0001F4E1 WebSocket", value=f"{ws_latency:.0f} ms", inline=True
             )
-            embed.set_footer(text="Brewed with love \u2615\ufe0f\u2728")
+            now = datetime.now(tz=self.bot.timezone)
+            now_str = now.strftime("%Y/%m/%d %H:%M")
+            embed.set_footer(text=f"Brewed with love \u2615\ufe0f\u2728 \u30fb {now_str}")
 
             if ctx.interaction:
                 await ctx.interaction.followup.send(embed=embed)

--- a/commands/setup.py
+++ b/commands/setup.py
@@ -1,0 +1,41 @@
+import logging
+from zoneinfo import ZoneInfo
+
+import discord
+from discord.ext import commands
+from discord import app_commands
+
+log = logging.getLogger(__name__)
+
+TIMEZONE_CHOICES = [
+    discord.app_commands.Choice(name="UTC", value="UTC"),
+    discord.app_commands.Choice(name="Asia/Tokyo", value="Asia/Tokyo"),
+    discord.app_commands.Choice(name="America/New_York", value="America/New_York"),
+]
+
+
+class Setup(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @commands.hybrid_command(name="setup", description="Configure the bot")
+    @app_commands.describe(timezone="Timezone to use for uptime")
+    @app_commands.choices(timezone=TIMEZONE_CHOICES)
+    async def setup_command(
+        self, ctx: commands.Context, timezone: str | None = None
+    ) -> None:
+        if timezone is None:
+            tzname = getattr(self.bot.timezone, "key", str(self.bot.timezone))
+            await ctx.send(f"Current timezone: {tzname}", ephemeral=True)
+            return
+        try:
+            tz = ZoneInfo(timezone)
+        except Exception:
+            await ctx.send("Invalid timezone", ephemeral=True)
+            return
+        self.bot.timezone = tz
+        await ctx.send(f"Timezone set to {timezone}", ephemeral=True)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Setup(bot))

--- a/commands/uptime.py
+++ b/commands/uptime.py
@@ -8,12 +8,11 @@ from utils import error_embed, humanize_delta
 
 log = logging.getLogger(__name__)
 
-PROGRESS_BLOCKS = 12  # 12分割のミニバー
+PROGRESS_BLOCKS = 20  # 20分割のミニバー
 
-def day_progress_bar(seconds: float) -> str:
-    """その日の経過割合(0-1)から簡易バーを作成."""
-    within_day = seconds % 86400
-    ratio = within_day / 86400
+def day_progress_bar(seconds_today: float) -> tuple[str, float]:
+    """0時を基準にした今日の進捗バー."""
+    ratio = max(0.0, min(1.0, seconds_today / 86400))
     filled = int(ratio * PROGRESS_BLOCKS)
     empty = PROGRESS_BLOCKS - filled
     return "▰" * filled + "▱" * empty, ratio * 100
@@ -50,24 +49,27 @@ class Uptime(commands.Cog):
             minutes = rem // 60
             seconds = rem % 60
 
-            bar, pct = day_progress_bar(total_seconds)
+            local_now = now.astimezone(self.bot.timezone)
+            midnight = local_now.replace(hour=0, minute=0, second=0, microsecond=0)
+            seconds_today = (local_now - midnight).total_seconds()
+            bar, pct = day_progress_bar(seconds_today)
 
             embed = discord.Embed(
-                title="⏱ Cappuccino Uptime",
+                title="\U0001F464 Cappuccino \u2615 Uptime",
                 description="Here's how long I've been awake!",
                 color=0x42A5F5,
                 timestamp=now
             )
 
             embed.add_field(
-                name="🟢 Uptime",
+                name="\u23F3 Uptime",
                 value=f"{human}\n`{days}d {hours}h {minutes}m {seconds}s`",
                 inline=True
             )
 
             ts = int(launch_time.timestamp())
             embed.add_field(
-                name="🗓 Started",
+                name="\U0001F4C5 Started",
                 value=f"<t:{ts}:F>\n<t:{ts}:R>",
                 inline=True
             )
@@ -78,7 +80,9 @@ class Uptime(commands.Cog):
                 inline=False
             )
 
-            embed.set_footer(text="Brewed with love ☕✨")
+            now_local = now.astimezone(self.bot.timezone)
+            now_str = now_local.strftime("%Y/%m/%d %H:%M")
+            embed.set_footer(text=f"Brewed with love ☕✨ ・ {now_str}")
 
             await self._reply(ctx, embed=embed)
         except Exception:


### PR DESCRIPTION
## Summary
- document `/setup` command in README
- format ping footer with complete local time
- show full local time in uptime footer

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687cab9c400c832cb81483abc3a063d1