### PR TITLE
Update timezone handling and embed timestamps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,3 @@ DISCORD_BOT_TOKEN=YOUR_TOKEN_HERE
 BOT_PREFIX=c!
 SUPPORT_SERVER_URL=https://example.com/support
 BOT_INVITE_URL=https://example.com/invite
-TIMEZONE=UTC

--- a/README.md
+++ b/README.md
@@ -21,12 +21,10 @@ DISCORD_BOT_TOKEN=YOUR_TOKEN_HERE
 BOT_PREFIX=c!
 SUPPORT_SERVER_URL=https://example.com/support
 BOT_INVITE_URL=https://example.com/invite
-TIMEZONE=UTC
 ...追加予定
 ```
 
-`TIMEZONE` は `uptime` コマンドなどで使用する基準となるタイムゾーンを指定します。
-起動後に `/setup` コマンドを使うことでボット実行中にタイムゾーンを変更できます。
+ボットのタイムゾーンは起動後に `/setup` コマンドを使って変更できます。
 
 `.env.example` を `.env` にコピーしてトークンや各種 URL を編集してください。
 

--- a/bot.py
+++ b/bot.py
@@ -28,12 +28,7 @@ class CappuccinoBot(commands.Bot):
         intents.message_content = True
         intents.members = True
         super().__init__(command_prefix=prefix, intents=intents)
-        tz_name = os.getenv("TIMEZONE", "UTC")
-        try:
-            self.timezone = ZoneInfo(tz_name)
-        except Exception:
-            log.warning("Invalid TIMEZONE %s, falling back to UTC", tz_name)
-            self.timezone = ZoneInfo("UTC")
+        self.timezone = ZoneInfo("UTC")
         self.launch_time = datetime.now(timezone.utc)
 
     async def setup_hook(self) -> None:  # type: ignore[override]

--- a/commands/ping.py
+++ b/commands/ping.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 import discord
 from discord.ext import commands
@@ -29,10 +29,12 @@ class Ping(commands.Cog):
                 api_latency = (time.perf_counter() - start) * 1000
             ws_latency = self.bot.latency * 1000
 
+            now_utc = datetime.now(timezone.utc)
             embed = discord.Embed(
                 title="\U0001F3D3 Cappuccino Ping",
                 description="Here's how fast I can respond!",
                 color=0xFFC0CB,
+                timestamp=now_utc,
             )
             embed.add_field(
                 name="\U0001F4BB API Latency", value=f"{api_latency:.0f} ms", inline=True
@@ -40,9 +42,7 @@ class Ping(commands.Cog):
             embed.add_field(
                 name="\U0001F4E1 WebSocket", value=f"{ws_latency:.0f} ms", inline=True
             )
-            now = datetime.now(tz=self.bot.timezone)
-            now_str = now.strftime("%Y/%m/%d %H:%M")
-            embed.set_footer(text=f"Brewed with love \u2615\ufe0f\u2728 \u30fb {now_str}")
+            embed.set_footer(text="Brewed with love \u2615\ufe0f\u2728")
 
             if ctx.interaction:
                 await ctx.interaction.followup.send(embed=embed)

--- a/commands/setup.py
+++ b/commands/setup.py
@@ -3,15 +3,56 @@ from zoneinfo import ZoneInfo
 
 import discord
 from discord.ext import commands
-from discord import app_commands
-
 log = logging.getLogger(__name__)
 
-TIMEZONE_CHOICES = [
-    discord.app_commands.Choice(name="UTC", value="UTC"),
-    discord.app_commands.Choice(name="Asia/Tokyo", value="Asia/Tokyo"),
-    discord.app_commands.Choice(name="America/New_York", value="America/New_York"),
-]
+TIMEZONE_MAP = {
+    "UTC": "UTC",
+    "Etc/GMT+12": "Etc/GMT+12",
+    "Etc/GMT+11": "Etc/GMT+11",
+    "Etc/GMT+10": "Etc/GMT+10",
+    "Etc/GMT+9": "Etc/GMT+9",
+    "Etc/GMT+8": "Etc/GMT+8",
+    "Etc/GMT+7": "Etc/GMT+7",
+    "Etc/GMT+6": "Etc/GMT+6",
+    "Etc/GMT+5": "Etc/GMT+5",
+    "Etc/GMT+4": "Etc/GMT+4",
+    "Etc/GMT+3": "Etc/GMT+3",
+    "Etc/GMT+2": "Etc/GMT+2",
+    "Etc/GMT+1": "Etc/GMT+1",
+    "Etc/GMT-1": "Etc/GMT-1",
+    "Etc/GMT-2": "Etc/GMT-2",
+    "Etc/GMT-3": "Etc/GMT-3",
+    "Etc/GMT-4": "Etc/GMT-4",
+    "Etc/GMT-5": "Etc/GMT-5",
+    "Etc/GMT-6": "Etc/GMT-6",
+    "Etc/GMT-7": "Etc/GMT-7",
+    "Etc/GMT-8": "Etc/GMT-8",
+    "Etc/GMT-9": "Etc/GMT-9",
+    "Etc/GMT-10": "Etc/GMT-10",
+    "Etc/GMT-11": "Etc/GMT-11",
+    "Etc/GMT-12": "Etc/GMT-12",
+    "Europe/London": "Europe/London",
+    "Europe/Paris": "Europe/Paris",
+    "Europe/Berlin": "Europe/Berlin",
+    "Europe/Moscow": "Europe/Moscow",
+    "Africa/Cairo": "Africa/Cairo",
+    "Africa/Johannesburg": "Africa/Johannesburg",
+    "Asia/Tokyo": "Asia/Tokyo",
+    "Asia/Seoul": "Asia/Seoul",
+    "Asia/Shanghai": "Asia/Shanghai",
+    "Asia/Hong_Kong": "Asia/Hong_Kong",
+    "Asia/Singapore": "Asia/Singapore",
+    "Asia/Kolkata": "Asia/Kolkata",
+    "Asia/Bangkok": "Asia/Bangkok",
+    "Australia/Sydney": "Australia/Sydney",
+    "Pacific/Auckland": "Pacific/Auckland",
+    "America/New_York": "America/New_York",
+    "America/Chicago": "America/Chicago",
+    "America/Denver": "America/Denver",
+    "America/Los_Angeles": "America/Los_Angeles",
+    "America/Mexico_City": "America/Mexico_City",
+    "America/Sao_Paulo": "America/Sao_Paulo",
+}
 
 
 class Setup(commands.Cog):
@@ -19,22 +60,20 @@ class Setup(commands.Cog):
         self.bot = bot
 
     @commands.hybrid_command(name="setup", description="Configure the bot")
-    @app_commands.describe(timezone="Timezone to use for uptime")
-    @app_commands.choices(timezone=TIMEZONE_CHOICES)
     async def setup_command(
         self, ctx: commands.Context, timezone: str | None = None
     ) -> None:
         if timezone is None:
             tzname = getattr(self.bot.timezone, "key", str(self.bot.timezone))
-            await ctx.send(f"Current timezone: {tzname}", ephemeral=True)
+            await ctx.send(f"Current timezone: {tzname}")
             return
-        try:
-            tz = ZoneInfo(timezone)
-        except Exception:
-            await ctx.send("Invalid timezone", ephemeral=True)
+
+        if timezone not in TIMEZONE_MAP:
+            await ctx.send("Unknown timezone. Use one of: " + ", ".join(TIMEZONE_MAP.keys()))
             return
-        self.bot.timezone = tz
-        await ctx.send(f"Timezone set to {timezone}", ephemeral=True)
+
+        self.bot.timezone = ZoneInfo(TIMEZONE_MAP[timezone])
+        await ctx.send(f"Timezone set to **{timezone}**")
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/commands/uptime.py
+++ b/commands/uptime.py
@@ -37,8 +37,8 @@ class Uptime(commands.Cog):
             launch_time: datetime = getattr(self.bot, "launch_time", datetime.now(timezone.utc))
             if launch_time.tzinfo is None:
                 launch_time = launch_time.replace(tzinfo=timezone.utc)
-            now = datetime.now(timezone.utc)
-            delta = now - launch_time
+            now_utc = datetime.now(timezone.utc)
+            delta = now_utc - launch_time
             total_seconds = int(delta.total_seconds())
 
             human = humanize_delta(total_seconds)
@@ -49,7 +49,7 @@ class Uptime(commands.Cog):
             minutes = rem // 60
             seconds = rem % 60
 
-            local_now = now.astimezone(self.bot.timezone)
+            local_now = now_utc.astimezone(self.bot.timezone)
             midnight = local_now.replace(hour=0, minute=0, second=0, microsecond=0)
             seconds_today = (local_now - midnight).total_seconds()
             bar, pct = day_progress_bar(seconds_today)
@@ -58,7 +58,7 @@ class Uptime(commands.Cog):
                 title="\U0001F464 Cappuccino \u2615 Uptime",
                 description="Here's how long I've been awake!",
                 color=0x42A5F5,
-                timestamp=now
+                timestamp=now_utc
             )
 
             embed.add_field(
@@ -80,9 +80,7 @@ class Uptime(commands.Cog):
                 inline=False
             )
 
-            now_local = now.astimezone(self.bot.timezone)
-            now_str = now_local.strftime("%Y/%m/%d %H:%M")
-            embed.set_footer(text=f"Brewed with love ☕✨ ・ {now_str}")
+            embed.set_footer(text="Brewed with love ☕✨")
 
             await self._reply(ctx, embed=embed)
         except Exception:


### PR DESCRIPTION
## Summary
- default timezone to UTC in `bot.py`
- manage timezone via `/setup` command using `zoneinfo`
- extend timezone list and validate selections
- simplify uptime and ping embeds to use Discord's timestamp localization
- remove timezone setting from `.env.example` and update docs

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_687cb062c118832ca5f5352811679d1f