### PR TITLE
Add offset based timezone setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ BOT_INVITE_URL=https://example.com/invite
 ...追加予定
 ```
 
-ボットのタイムゾーンは起動後に `/setup` コマンドを使って変更できます。
+ボットのタイムゾーンは起動後に `/setup` コマンドで指定します。
+基本は `/setup timezone:+9` のように UTC からのオフセットを入力します。
+夏時間を加味したい場合は `/setup timezone:+10 summertime:+1` のように
+`summertime` 引数で追加のオフセットを指定してください。
 
 `.env.example` を `.env` にコピーしてトークンや各種 URL を編集してください。
 

--- a/commands/setup.py
+++ b/commands/setup.py
@@ -1,58 +1,12 @@
 import logging
-from zoneinfo import ZoneInfo
+import re
+from datetime import timedelta, timezone as dt_timezone
 
 import discord
 from discord.ext import commands
 log = logging.getLogger(__name__)
 
-TIMEZONE_MAP = {
-    "UTC": "UTC",
-    "Etc/GMT+12": "Etc/GMT+12",
-    "Etc/GMT+11": "Etc/GMT+11",
-    "Etc/GMT+10": "Etc/GMT+10",
-    "Etc/GMT+9": "Etc/GMT+9",
-    "Etc/GMT+8": "Etc/GMT+8",
-    "Etc/GMT+7": "Etc/GMT+7",
-    "Etc/GMT+6": "Etc/GMT+6",
-    "Etc/GMT+5": "Etc/GMT+5",
-    "Etc/GMT+4": "Etc/GMT+4",
-    "Etc/GMT+3": "Etc/GMT+3",
-    "Etc/GMT+2": "Etc/GMT+2",
-    "Etc/GMT+1": "Etc/GMT+1",
-    "Etc/GMT-1": "Etc/GMT-1",
-    "Etc/GMT-2": "Etc/GMT-2",
-    "Etc/GMT-3": "Etc/GMT-3",
-    "Etc/GMT-4": "Etc/GMT-4",
-    "Etc/GMT-5": "Etc/GMT-5",
-    "Etc/GMT-6": "Etc/GMT-6",
-    "Etc/GMT-7": "Etc/GMT-7",
-    "Etc/GMT-8": "Etc/GMT-8",
-    "Etc/GMT-9": "Etc/GMT-9",
-    "Etc/GMT-10": "Etc/GMT-10",
-    "Etc/GMT-11": "Etc/GMT-11",
-    "Etc/GMT-12": "Etc/GMT-12",
-    "Europe/London": "Europe/London",
-    "Europe/Paris": "Europe/Paris",
-    "Europe/Berlin": "Europe/Berlin",
-    "Europe/Moscow": "Europe/Moscow",
-    "Africa/Cairo": "Africa/Cairo",
-    "Africa/Johannesburg": "Africa/Johannesburg",
-    "Asia/Tokyo": "Asia/Tokyo",
-    "Asia/Seoul": "Asia/Seoul",
-    "Asia/Shanghai": "Asia/Shanghai",
-    "Asia/Hong_Kong": "Asia/Hong_Kong",
-    "Asia/Singapore": "Asia/Singapore",
-    "Asia/Kolkata": "Asia/Kolkata",
-    "Asia/Bangkok": "Asia/Bangkok",
-    "Australia/Sydney": "Australia/Sydney",
-    "Pacific/Auckland": "Pacific/Auckland",
-    "America/New_York": "America/New_York",
-    "America/Chicago": "America/Chicago",
-    "America/Denver": "America/Denver",
-    "America/Los_Angeles": "America/Los_Angeles",
-    "America/Mexico_City": "America/Mexico_City",
-    "America/Sao_Paulo": "America/Sao_Paulo",
-}
+TIMEZONE_RE = re.compile(r"^([+-]?)(\d{1,2})$")
 
 
 class Setup(commands.Cog):
@@ -61,19 +15,36 @@ class Setup(commands.Cog):
 
     @commands.hybrid_command(name="setup", description="Configure the bot")
     async def setup_command(
-        self, ctx: commands.Context, timezone: str | None = None
+        self,
+        ctx: commands.Context,
+        timezone: str | None = None,
+        summertime: int | None = 0,
     ) -> None:
         if timezone is None:
             tzname = getattr(self.bot.timezone, "key", str(self.bot.timezone))
             await ctx.send(f"Current timezone: {tzname}")
             return
 
-        if timezone not in TIMEZONE_MAP:
-            await ctx.send("Unknown timezone. Use one of: " + ", ".join(TIMEZONE_MAP.keys()))
-            return
+        tz_param = timezone.strip().upper()
+        if tz_param == "UTC":
+            offset = 0
+        else:
+            m = TIMEZONE_RE.fullmatch(tz_param)
+            if not m:
+                await ctx.send("Invalid timezone. Use like +9 or -5 or UTC.")
+                return
+            sign = -1 if m.group(1) == "-" else 1
+            offset = sign * int(m.group(2))
 
-        self.bot.timezone = ZoneInfo(TIMEZONE_MAP[timezone])
-        await ctx.send(f"Timezone set to **{timezone}**")
+        if summertime:
+            try:
+                offset += int(summertime)
+            except ValueError:
+                await ctx.send("Invalid summertime offset.")
+                return
+
+        self.bot.timezone = dt_timezone(timedelta(hours=offset))
+        await ctx.send(f"Timezone set to UTC{offset:+d}")
 
 
 async def setup(bot: commands.Bot) -> None:


### PR DESCRIPTION
## Summary
- simplify setup command
- accept timezone offsets like `+9`
- allow optional `summertime` offset
- document new setup command usage

## Testing
- `python -m py_compile bot.py commands/*.py utils.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687cb9d9dfb8832c88a9c219ce1a4dfd