### PR TITLE
Add VOICEVOX TTS and music features

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ DISCORD_BOT_TOKEN=YOUR_TOKEN_HERE
 BOT_PREFIX=c!
 SUPPORT_SERVER_URL=https://example.com/support
 BOT_INVITE_URL=https://example.com/invite
+VOICEVOX_URL=http://localhost:50021

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
 # Cappuccino
 指示されたことに従い、DiscordBOTを完成させてください。
 また、bot.py にすべてのコマンドを書くのではなく、commands ディレクトリに配置した各 Python ファイルで個別に管理してください。
-DiscordBOT のトークンは `.env.example` に `DISCORD_BOT_TOKEN` として記載し、実際の値は `.env` に保存してください。さらに、サポートサーバーの URL と BOT の招待 URL を `SUPPORT_SERVER_URL`、`BOT_INVITE_URL` として追加し、`.env` で適切な値に置き換えてください。
+DiscordBOT のトークンは `.env.example` に `DISCORD_BOT_TOKEN` として記載し、実際の値は `.env` に保存してください。さらに、サポートサーバーの URL と BOT の招待 URL を `SUPPORT_SERVER_URL`、`BOT_INVITE_URL` として追加し、`.env` で適切な値に置き換えてください。VOICEVOX エンジンの URL は `VOICEVOX_URL` として記載し、環境に合わせて設定してください。

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DiscordCappuccino
 
-簡易な Discord Bot のサンプルです。`commands/` 以下の拡張を読み込み、スラッシュコマンドを中心に動作します。
+簡易な Discord Bot のサンプルです。`commands/` 以下の拡張を読み込み、スラッシュコマンドを中心に動作します。VOICEVOX を利用した読み上げ機能と、YouTube などの音源を再生する簡易音楽プレイヤーを搭載しています。
 
 ## フォルダ構成例
 
@@ -21,6 +21,7 @@ DISCORD_BOT_TOKEN=YOUR_TOKEN_HERE
 BOT_PREFIX=c!
 SUPPORT_SERVER_URL=https://example.com/support
 BOT_INVITE_URL=https://example.com/invite
+VOICEVOX_URL=http://localhost:50021
 ...追加予定
 ```
 
@@ -34,7 +35,8 @@ BOT_INVITE_URL=https://example.com/invite
 2. 仮想環境を作成してアクティベートします。
 3. `pip install -r requirements.txt` で依存をインストールします。
 4. `.env.example` を `.env` にコピーし、`DISCORD_BOT_TOKEN` を設定します。
-5. `python bot.py` を実行して起動します。
+5. VOICEVOX エンジンを起動し、`VOICEVOX_URL` を設定します。
+6. `python bot.py` を実行して起動します。
 
 ## コマンド追加ガイド
 
@@ -49,6 +51,11 @@ class Example(commands.Cog):
 async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(Example(bot))
 ```
+
+## 主な機能
+
+- VOICEVOX によるテキスト読み上げ (`/join`, `/setvoice`, `/disconnect`, `/skip`)
+- YouTube 等の音源再生 (`/play`, `/queue`, `/remove`, `/keep`, `/seek`, `/rewind`, `/forward`, `/stop`)
 
 ## FAQ
 

--- a/commands/music.py
+++ b/commands/music.py
@@ -1,0 +1,172 @@
+import asyncio
+import collections
+import re
+from typing import Deque, Tuple
+
+import discord
+from discord.ext import commands
+from yt_dlp import YoutubeDL
+
+YTDL_OPTS = {
+    "format": "bestaudio/best",
+    "quiet": True,
+    "default_search": "ytsearch",
+}
+
+FFMPEG_OPTS = {
+    "options": "-vn",
+}
+
+class MusicState:
+    def __init__(self):
+        self.queue: Deque[Tuple[str, str]] = collections.deque()
+        self.current: Tuple[str, str] | None = None
+        self.source: discord.PCMVolumeTransformer | None = None
+        self.volume: float = 1.0
+        self.next_event = asyncio.Event()
+        self.position: int = 0
+
+    def reduce_volume(self):
+        if self.source:
+            self.source.volume = 0.3
+
+    def restore_volume(self):
+        if self.source:
+            self.source.volume = self.volume
+
+class Music(commands.Cog):
+    """Simple music player using yt-dlp and ffmpeg."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.states: dict[int, MusicState] = {}
+        self.ytdl = YoutubeDL(YTDL_OPTS)
+
+    def get_state(self, guild_id: int) -> MusicState:
+        return self.states.setdefault(guild_id, MusicState())
+
+    async def ensure_voice(self, ctx: commands.Context) -> discord.VoiceClient | None:
+        if ctx.voice_client and ctx.voice_client.is_connected():
+            return ctx.voice_client
+        if not ctx.author.voice or not ctx.author.voice.channel:
+            await ctx.send("VCに参加してから実行してね")
+            return None
+        return await ctx.author.voice.channel.connect()
+
+    async def start_player(self, ctx: commands.Context, state: MusicState) -> None:
+        vc = ctx.voice_client
+        while state.queue and vc and vc.is_connected():
+            title, url = state.queue.popleft()
+            state.current = (title, url)
+            before = f"-ss {state.position}" if state.position else ""
+            src = discord.FFmpegPCMAudio(url, before_options=before, **FFMPEG_OPTS)
+            state.source = discord.PCMVolumeTransformer(src, volume=state.volume)
+            vc.play(state.source, after=lambda e: self.bot.loop.call_soon_threadsafe(state.next_event.set))
+            await ctx.send(f"Now playing: {title}")
+            await state.next_event.wait()
+            state.next_event.clear()
+            state.position = 0
+            state.source = None
+            state.current = None
+        if vc and vc.is_connected():
+            await vc.disconnect()
+
+    def reduce_volume(self, guild_id: int) -> None:
+        state = self.states.get(guild_id)
+        if state:
+            state.reduce_volume()
+
+    def restore_volume(self, guild_id: int) -> None:
+        state = self.states.get(guild_id)
+        if state:
+            state.restore_volume()
+
+    @commands.hybrid_command(name="play", description="Add music to queue")
+    async def play(self, ctx: commands.Context, *, query: str) -> None:
+        vc = await self.ensure_voice(ctx)
+        if not vc:
+            return
+        loop = self.bot.loop
+        data = await loop.run_in_executor(None, lambda: self.ytdl.extract_info(query, download=False))
+        if "entries" in data:
+            data = data["entries"][0]
+        url = data["url"]
+        title = data.get("title", "Unknown")
+        state = self.get_state(ctx.guild.id)
+        state.queue.append((title, url))
+        await ctx.send(f"Queued: {title}")
+        if not vc.is_playing() and not vc.is_paused():
+            await self.start_player(ctx, state)
+
+    @commands.hybrid_command(name="queue", description="Show music queue")
+    async def queue_cmd(self, ctx: commands.Context) -> None:
+        state = self.states.get(ctx.guild.id)
+        if not state or not state.queue:
+            await ctx.send("キューは空だよ")
+            return
+        desc = "\n".join(f"{i+1}. {t}" for i, (t, _) in enumerate(state.queue))
+        await ctx.send(desc)
+
+    @commands.hybrid_command(name="remove", description="Remove track from queue")
+    async def remove(self, ctx: commands.Context, index: int) -> None:
+        state = self.states.get(ctx.guild.id)
+        if not state or not (1 <= index <= len(state.queue)):
+            await ctx.send("番号が無効です")
+            return
+        removed = state.queue[index-1]
+        del state.queue[index-1]
+        await ctx.send(f"Removed: {removed[0]}")
+
+    @commands.hybrid_command(name="keep", description="Keep only specified tracks")
+    async def keep(self, ctx: commands.Context, *indices: int) -> None:
+        state = self.states.get(ctx.guild.id)
+        if not state or not indices:
+            await ctx.send("番号を指定してね")
+            return
+        new_queue = [t for i, t in enumerate(state.queue, 1) if i in indices]
+        state.queue = collections.deque(new_queue)
+        await ctx.send("キューを更新しました")
+
+    @commands.hybrid_command(name="seek", description="Seek current track")
+    async def seek(self, ctx: commands.Context, position: int) -> None:
+        state = self.states.get(ctx.guild.id)
+        if not state or not state.current or not ctx.voice_client:
+            await ctx.send("再生中の曲がありません")
+            return
+        state.position = position
+        ctx.voice_client.stop()
+        await ctx.send(f"{position}秒から再生します")
+
+    @commands.hybrid_command(name="rewind", description="Rewind current track")
+    async def rewind(self, ctx: commands.Context, seconds: int) -> None:
+        state = self.states.get(ctx.guild.id)
+        if not state or not state.current:
+            await ctx.send("再生中の曲がありません")
+            return
+        new_pos = max(0, state.position - seconds)
+        state.position = new_pos
+        if ctx.voice_client:
+            ctx.voice_client.stop()
+        await ctx.send(f"{seconds}秒巻き戻し")
+
+    @commands.hybrid_command(name="forward", description="Forward current track")
+    async def forward(self, ctx: commands.Context, seconds: int) -> None:
+        state = self.states.get(ctx.guild.id)
+        if not state or not state.current:
+            await ctx.send("再生中の曲がありません")
+            return
+        state.position += seconds
+        if ctx.voice_client:
+            ctx.voice_client.stop()
+        await ctx.send(f"{seconds}秒早送り")
+
+    @commands.hybrid_command(name="stop", description="Disconnect and clear queue")
+    async def stop(self, ctx: commands.Context) -> None:
+        if ctx.voice_client:
+            await ctx.voice_client.disconnect()
+        if ctx.guild.id in self.states:
+            self.states.pop(ctx.guild.id)
+        await ctx.send("停止しました")
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Music(bot))

--- a/commands/tts.py
+++ b/commands/tts.py
@@ -1,0 +1,105 @@
+import asyncio
+import aiohttp
+import discord
+from discord.ext import commands
+from typing import Dict, List, Tuple
+
+import os
+
+VOICEVOX_URL = os.getenv("VOICEVOX_URL", "http://localhost:50021")
+
+class TTSState:
+    def __init__(self):
+        self.channel_id: int | None = None
+        self.speaker: int = 1
+        self.speed: float = 1.0
+        self.queue: asyncio.Queue[str] = asyncio.Queue()
+        self.playing: bool = False
+
+class TTS(commands.Cog):
+    """Read messages in a channel using VOICEVOX."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.states: Dict[int, TTSState] = {}
+        self.loop_task: Dict[int, asyncio.Task] = {}
+
+    def get_state(self, guild_id: int) -> TTSState:
+        return self.states.setdefault(guild_id, TTSState())
+
+    async def tts_loop(self, guild_id: int, voice: discord.VoiceClient) -> None:
+        state = self.get_state(guild_id)
+        async with aiohttp.ClientSession() as sess:
+            while voice.is_connected():
+                text = await state.queue.get()
+                try:
+                    query_url = f"{VOICEVOX_URL}/audio_query"
+                    synthesis_url = f"{VOICEVOX_URL}/synthesis"
+                    params = {"text": text, "speaker": state.speaker}
+                    async with sess.post(query_url, params=params) as r:
+                        query = await r.json()
+                    query["speedScale"] = state.speed
+                    async with sess.post(synthesis_url, params={"speaker": state.speaker}, json=query) as r:
+                        audio = await r.read()
+                    source = discord.PCMVolumeTransformer(discord.FFmpegPCMAudio(audio, pipe=True))
+                    music_cog = self.bot.get_cog("Music")
+                    if music_cog:
+                        music_cog.reduce_volume(guild_id)
+                    voice.play(source)
+                    while voice.is_playing():
+                        await asyncio.sleep(0.1)
+                    if music_cog:
+                        music_cog.restore_volume(guild_id)
+                except Exception:
+                    pass
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message) -> None:
+        if message.author.bot or not message.guild:
+            return
+        state = self.states.get(message.guild.id)
+        if not state or state.channel_id != message.channel.id:
+            return
+        await state.queue.put(message.clean_content)
+
+    @commands.hybrid_command(name="join", description="Join VC and start reading")
+    async def join(self, ctx: commands.Context) -> None:
+        if not ctx.author.voice or not ctx.author.voice.channel:
+            await ctx.send("VCに参加してから実行してね")
+            return
+        voice = ctx.author.voice.channel
+        vc = ctx.voice_client
+        if not vc or not vc.is_connected():
+            vc = await voice.connect()
+        state = self.get_state(ctx.guild.id)
+        state.channel_id = ctx.channel.id
+        if ctx.guild.id not in self.loop_task or self.loop_task[ctx.guild.id].done():
+            self.loop_task[ctx.guild.id] = self.bot.loop.create_task(self.tts_loop(ctx.guild.id, vc))
+        await ctx.send("読み上げを開始します")
+
+    @commands.hybrid_command(name="disconnect", description="Disconnect from VC")
+    async def disconnect(self, ctx: commands.Context) -> None:
+        if ctx.voice_client:
+            await ctx.voice_client.disconnect()
+        if ctx.guild.id in self.loop_task:
+            self.loop_task[ctx.guild.id].cancel()
+        await ctx.send("切断しました")
+
+    @commands.hybrid_command(name="setvoice", description="Set speaker and speed")
+    @commands.app_commands.describe(speaker="VOICEVOX speaker id", speed="Speed scale 0.5-2.0")
+    async def setvoice(self, ctx: commands.Context, speaker: int, speed: float = 1.0) -> None:
+        state = self.get_state(ctx.guild.id)
+        state.speaker = speaker
+        state.speed = speed
+        await ctx.send(f"話者:{speaker} 速度:{speed}")
+
+    @commands.hybrid_command(name="skip", description="Skip current speech")
+    async def skip(self, ctx: commands.Context) -> None:
+        if ctx.voice_client and ctx.voice_client.is_playing():
+            ctx.voice_client.stop()
+            await ctx.send("スキップしました")
+        else:
+            await ctx.send("再生中の読み上げがありません")
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(TTS(bot))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 discord.py>=2.0.0
 python-dotenv
+yt_dlp
+aiohttp


### PR DESCRIPTION
## Summary
- implement VOICEVOX based TTS with `/join`, `/setvoice`, `/disconnect`, `/skip`
- add simple music player commands (`/play`, `/queue`, `/remove`, `/keep`, `/seek`, `/rewind`, `/forward`, `/stop`)
- document new features and VOICEVOX_URL in README and AGENTS
- add yt_dlp and aiohttp requirements

## Testing
- `python -m py_compile bot.py utils.py commands/*.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687cc8f5bea4832c8a18c74b08ce4768