### PR TITLE
Fix slash command initialization issues

### DIFF
--- a/commands/music.py
+++ b/commands/music.py
@@ -117,7 +117,14 @@ class Music(commands.Cog):
         del state.queue[index-1]
         await ctx.send(f"Removed: {removed[0]}")
 
-    @commands.hybrid_command(name="keep", description="Keep only specified tracks")
+    # HybirdCommand cannot handle variable positional arguments when registering
+    # as an application command. Disable the app command version so that the
+    # prefix command can still accept multiple indices.
+    @commands.hybrid_command(
+        name="keep",
+        description="Keep only specified tracks",
+        with_app_command=False,
+    )
     async def keep(self, ctx: commands.Context, *indices: int) -> None:
         state = self.states.get(ctx.guild.id)
         if not state or not indices:

--- a/commands/tts.py
+++ b/commands/tts.py
@@ -2,6 +2,7 @@ import asyncio
 import aiohttp
 import discord
 from discord.ext import commands
+from discord import app_commands
 from typing import Dict, List, Tuple
 
 import os
@@ -86,7 +87,7 @@ class TTS(commands.Cog):
         await ctx.send("切断しました")
 
     @commands.hybrid_command(name="setvoice", description="Set speaker and speed")
-    @commands.app_commands.describe(speaker="VOICEVOX speaker id", speed="Speed scale 0.5-2.0")
+    @app_commands.describe(speaker="VOICEVOX speaker id", speed="Speed scale 0.5-2.0")
     async def setvoice(self, ctx: commands.Context, speaker: int, speed: float = 1.0) -> None:
         state = self.get_state(ctx.guild.id)
         state.speaker = speaker


### PR DESCRIPTION
## Summary
- disable slash command registration for `keep` which accepts variable arguments
- import `app_commands` correctly and fix decorator in `tts` commands

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile bot.py commands/*.py utils.py`
- `python bot.py` *(fails: valid DISCORD_BOT_TOKEN not set)*

------
https://chatgpt.com/codex/tasks/task_e_687ccafcc88c832ca53da1d7b1ab1ffb